### PR TITLE
feat : Github 로그인 기능

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ bin/
 
 ### IntelliJ IDEA ###
 application-mysql.properties
+application-github.properties
+application-jwt.properties
 
 .idea
 *.iws

--- a/build.gradle
+++ b/build.gradle
@@ -26,12 +26,23 @@ repositories {
 dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 
+	implementation('org.springframework.boot:spring-boot-starter-oauth2-client')
+
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	implementation 'jakarta.servlet:jakarta.servlet-api:6.0.0'
+	implementation 'jakarta.persistence:jakarta.persistence-api:3.1.0'
+
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/com/example/Backend/auth/AuthApi.java
+++ b/src/main/java/com/example/Backend/auth/AuthApi.java
@@ -24,7 +24,11 @@ public class AuthApi {
     private final AuthService authService;
     private final JwtUtil jwtUtil;
     private final UserRepository userRepository;
-
+    @Operation(summary = "GitHub OAuth Callback", description = "GitHub OAuth 흐름에서 콜백을 처리하고 JWT 토큰을 생성하고 쿠키를 설정합니다.")
+    @ApiResponses({
+                @ApiResponse(responseCode = "200", description = "Login successful"),
+                @ApiResponse(responseCode = "401", description = "Authentication failed")
+            })
     @GetMapping("/github/callback")
     public ResponseEntity<?> githubCallback(@RequestParam String code, HttpServletResponse response) {
         String accessToken = authService.getAccessToken(code);
@@ -45,6 +49,12 @@ public class AuthApi {
         return ResponseEntity.ok(Map.of("message", "Login success"));
     }
 
+    @Operation(summary = "GitHub Login", description = "GitHub OAuth 코드를 처리하여 사용자를 인증하고 JWT 토큰을 생성하며 쿠키를 설정합니다.")
+        @ApiResponses({
+                @ApiResponse(responseCode = "200", description = "Login successful"),
+                @ApiResponse(responseCode = "400", description = "Invalid request"),
+                @ApiResponse(responseCode = "401", description = "Authentication failed")
+            })
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody Map<String, String> payload, HttpServletResponse response) {
         String code = payload.get("code");
@@ -92,6 +102,10 @@ public class AuthApi {
         }
     }
 
+    @Operation(summary = "Logout", description = "access_token 및 refresh_token 쿠키를 지웁니다.")
+    @ApiResponses({
+                @ApiResponse(responseCode = "200", description = "Logout successful")
+            })
     @PostMapping("/logout")
     public ResponseEntity<?> logout(HttpServletResponse response) {
         ResponseCookie expiredAccess = ResponseCookie.from("access_token", "")
@@ -105,6 +119,11 @@ public class AuthApi {
         return ResponseEntity.ok(Map.of("message", "Logout success"));
     }
 
+    @Operation(summary = "Reissue Access Token", description = "refresh_token 을 사용하여 access_token 을 다시 발급합니다.")
+        @ApiResponses({
+                @ApiResponse(responseCode = "200", description = "Access token reissued successfully"),
+                @ApiResponse(responseCode = "401", description = "Refresh token is missing or invalid")
+            })
     @PostMapping("/reissue")
     public ResponseEntity<?> reissue(
             @CookieValue(name = "refresh_token", required = false) String refreshToken,

--- a/src/main/java/com/example/Backend/auth/AuthApi.java
+++ b/src/main/java/com/example/Backend/auth/AuthApi.java
@@ -1,0 +1,131 @@
+package com.example.Backend.auth;
+
+import com.example.Backend.config.JwtUtil;
+import com.example.Backend.user.User;
+import com.example.Backend.user.UserRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthApi {
+
+    private final AuthService authService;
+    private final JwtUtil jwtUtil;
+    private final UserRepository userRepository;
+
+    @GetMapping("/github/callback")
+    public ResponseEntity<?> githubCallback(@RequestParam String code, HttpServletResponse response) {
+        String accessToken = authService.getAccessToken(code);
+        User user = authService.getUserInfoAndSave(accessToken);
+
+        String jwtAccess = jwtUtil.generateAccessToken(user.getId().toString());
+        String jwtRefresh = jwtUtil.generateRefreshToken(user.getId().toString());
+
+        ResponseCookie accessCookie = ResponseCookie.from("access_token", jwtAccess)
+                .httpOnly(true).secure(true).path("/").maxAge(1800).build();
+
+        ResponseCookie refreshCookie = ResponseCookie.from("refresh_token", jwtRefresh)
+                .httpOnly(true).secure(true).path("/").maxAge(604800).build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
+
+        return ResponseEntity.ok(Map.of("message", "Login success"));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@RequestBody Map<String, String> payload, HttpServletResponse response) {
+        String code = payload.get("code");
+
+        String githubAccessToken = authService.getAccessToken(code);
+        User user = authService.getUserInfoAndSave(githubAccessToken);
+
+        String jwtAccess = jwtUtil.generateAccessToken(user.getId().toString());
+        String jwtRefresh = jwtUtil.generateRefreshToken(user.getId().toString());
+
+        ResponseCookie accessCookie = ResponseCookie.from("access_token", jwtAccess)
+                .httpOnly(true).secure(true).path("/").maxAge(1800).build();
+
+        ResponseCookie refreshCookie = ResponseCookie.from("refresh_token", jwtRefresh)
+                .httpOnly(true).secure(true).path("/").maxAge(604800).build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
+
+        return ResponseEntity.ok(Map.of("message", "Login success"));
+    }
+
+    @Operation(summary = "로그인된 유저 정보 조회", description = "access_token 쿠키가 유효하면 로그인한 유저의 정보를 반환합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "유저 정보 반환 성공"),
+            @ApiResponse(responseCode = "401", description = "토큰 없음 또는 유효하지 않음")
+    })
+    @GetMapping("/me")
+    public ResponseEntity<?> getLoginUser(@CookieValue(name = "access_token", required = false) String token) {
+        if (token == null)
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Access token is missing");
+
+        try {
+            String userId = jwtUtil.validateAndExtractSubject(token);
+            return userRepository.findById(Long.valueOf(userId))
+                    .map(user -> ResponseEntity.ok(Map.of(
+                            "id", user.getId(),
+                            "name", user.getName(),
+                            "email", user.getEmail(),
+                            "avatar", user.getAvatarUrl()
+                    )))
+                    .orElse(ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("message", "Access token is missing")));
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
+        }
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout(HttpServletResponse response) {
+        ResponseCookie expiredAccess = ResponseCookie.from("access_token", "")
+                .httpOnly(true).secure(true).path("/").maxAge(0).build();
+        ResponseCookie expiredRefresh = ResponseCookie.from("refresh_token", "")
+                .httpOnly(true).secure(true).path("/").maxAge(0).build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, expiredAccess.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, expiredRefresh.toString());
+
+        return ResponseEntity.ok(Map.of("message", "Logout success"));
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<?> reissue(
+            @CookieValue(name = "refresh_token", required = false) String refreshToken,
+            HttpServletResponse response
+    ) {
+        if (refreshToken == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Refresh token is missing");
+        }
+
+        try {
+            String userId = jwtUtil.validateAndExtractSubject(refreshToken);
+            String newAccessToken = jwtUtil.generateAccessToken(userId);
+
+            ResponseCookie accessCookie = ResponseCookie.from("access_token", newAccessToken)
+                    .httpOnly(true).secure(true).path("/").maxAge(1800).build();
+
+            response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
+            return ResponseEntity.ok(Map.of("message", "Access token reissued"));
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
+        }
+    }
+
+}

--- a/src/main/java/com/example/Backend/auth/AuthService.java
+++ b/src/main/java/com/example/Backend/auth/AuthService.java
@@ -1,0 +1,73 @@
+package com.example.Backend.auth;
+
+import com.example.Backend.user.User;
+import com.example.Backend.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Value("${github.client-id}")
+    private String clientId;
+
+    @Value("${github.client-secret}")
+    private String clientSecret;
+
+    public String getAccessToken(String code) {
+        String url = "https://github.com/login/oauth/access_token";
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("client_id", clientId);
+        params.add("client_secret", clientSecret);
+        params.add("code", code);
+
+        HttpEntity<?> request = new HttpEntity<>(params, headers);
+        ResponseEntity<Map> response = restTemplate.postForEntity(url, request, Map.class);
+
+        return (String) response.getBody().get("access_token");
+    }
+
+    public User getUserInfoAndSave(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+        ResponseEntity<Map> response = restTemplate.exchange(
+                "https://api.github.com/user",
+                HttpMethod.GET,
+                request,
+                Map.class
+        );
+
+        Map<String, Object> body = response.getBody();
+        String githubId = String.valueOf(body.get("id"));
+        String name = (String) body.get("name");
+        String email = (String) body.get("email");
+        String avatar = (String) body.get("avatar_url");
+
+        return userRepository.findByGithubId(githubId)
+                .orElseGet(() -> userRepository.save(
+                        User.builder()
+                                .githubId(githubId)
+                                .name(name != null ? name : "unknown")
+                                .email(email != null ? email : "unknown@example.com")
+                                .avatarUrl(avatar)
+                                .build()
+                ));
+    }
+}

--- a/src/main/java/com/example/Backend/config/JwtUtil.java
+++ b/src/main/java/com/example/Backend/config/JwtUtil.java
@@ -1,0 +1,68 @@
+package com.example.Backend.config;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Value("${jwt.access-token-exp}")
+    private long accessTokenExp;
+
+    @Value("${jwt.refresh-token-exp}")
+    private long refreshTokenExp;
+
+    private Key key;
+
+    @PostConstruct
+    public void init() {
+        byte[] decoded = Decoders.BASE64.decode(secret);
+        this.key = Keys.hmacShaKeyFor(decoded);
+    }
+
+    public String generateAccessToken(String userId) {
+        return Jwts.builder()
+                .setSubject(userId)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + accessTokenExp * 1000))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String generateRefreshToken(String userId) {
+        return Jwts.builder()
+                .setSubject(userId)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + refreshTokenExp * 1000))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String validateAndExtractSubject(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody()
+                    .getSubject();
+        } catch (ExpiredJwtException e) {
+            throw new RuntimeException("Access token expired");
+        } catch (JwtException e) {
+            throw new RuntimeException("Invalid token");
+        }
+    }
+}

--- a/src/main/java/com/example/Backend/question/QuestionService.java
+++ b/src/main/java/com/example/Backend/question/QuestionService.java
@@ -20,8 +20,9 @@ public class QuestionService {
     private final QuestionRepository questionRepository;
 
     @Transactional
-    public QuestionResponseDto createUserAndGetQuestions(QuestionRequestDto requestDto) { //TODO 2차 목표 진행 시 로그인으로 User 생성하도록 변경
-        User user = userRepository.save(new User());
+    public QuestionResponseDto getQuestionsForAuthenticatedUser(Long userId, QuestionRequestDto requestDto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다."));
 
         List<Question> personalityQuestions = questionRepository.findPersonalityQuestions(requestDto.getJobId(), requestDto.getPersonalityCount());
 

--- a/src/main/java/com/example/Backend/user/User.java
+++ b/src/main/java/com/example/Backend/user/User.java
@@ -17,8 +17,13 @@ public class User {
     @Column(name = "id", unique = true, nullable = false)
     private Long id;
 
+    @Column(unique = true)
     private String githubId;
+
+    @Column(nullable = false)
     private String name;
+
+    @Column(nullable = false)
     private String email;
     private String avatarUrl;
 }

--- a/src/main/java/com/example/Backend/user/User.java
+++ b/src/main/java/com/example/Backend/user/User.java
@@ -2,12 +2,13 @@ package com.example.Backend.user;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
-@NoArgsConstructor
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 @Table(name = "User")
 public class User {
 
@@ -15,4 +16,9 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", unique = true, nullable = false)
     private Long id;
+
+    private String githubId;
+    private String name;
+    private String email;
+    private String avatarUrl;
 }

--- a/src/main/java/com/example/Backend/user/UserRepository.java
+++ b/src/main/java/com/example/Backend/user/UserRepository.java
@@ -2,5 +2,8 @@ package com.example.Backend.user;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByGithubId(String githubId);
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,2 @@
 spring.application.name=Backend
-spring.profiles.include=mysql
+spring.profiles.include=mysql, github, jwt


### PR DESCRIPTION
## 📌 관련 이슈

- closed: #8

## ✨ PR 세부 내용

1. Github 연동으로 로그인 구현
2. 기존에 User 생성 로직을 로그인에 성공할 경우 생성하도록 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added GitHub OAuth login and JWT-based authentication with endpoints for login, logout, token reissue, and fetching user info.
  - User entity now stores GitHub ID, name, email, and avatar URL.
- **Improvements**
  - Question retrieval endpoint now requires authentication and provides proper unauthorized responses.
- **Chores**
  - Updated dependencies to support OAuth2, JWT, Jakarta Servlet, and Persistence APIs.
  - Expanded configuration to include GitHub and JWT profiles.
  - Updated .gitignore to exclude new configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->